### PR TITLE
tools: Add benchmarking tools to meta-agl-early

### DIFF
--- a/meta-agl-early/recipes-benchmark/dmidecode/dmidecode_3.2.bb
+++ b/meta-agl-early/recipes-benchmark/dmidecode/dmidecode_3.2.bb
@@ -1,0 +1,24 @@
+SUMMARY = "DMI (Desktop Management Interface) table related utilities"
+HOMEPAGE = "http://www.nongnu.org/dmidecode/"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "${SAVANNAH_NONGNU_MIRROR}/dmidecode/${BP}.tar.xz \
+	   file://0001-Fix-Redfish-Hostname-print-length.patch \
+	   file://0002-Add-Logical-non-volatile-device-to-the-memory-device-types.patch \
+           "
+
+COMPATIBLE_HOST = "(i.86|x86_64|aarch64|arm|powerpc|powerpc64).*-linux"
+
+EXTRA_OEMAKE = "-e MAKEFLAGS="
+
+# The upstream buildsystem uses 'docdir' as the path where it puts AUTHORS,
+# README, etc, but we don't want those in the root of our docdir.
+docdir .= "/${BPN}"
+
+do_install() {
+	oe_runmake DESTDIR="${D}" install
+}
+
+SRC_URI[md5sum] = "9cc2e27e74ade740a25b1aaf0412461b"
+SRC_URI[sha256sum] = "077006fa2da0d06d6383728112f2edef9684e9c8da56752e97cd45a11f838edd"

--- a/meta-agl-early/recipes-benchmark/dmidecode/files/0001-Fix-Redfish-Hostname-print-length.patch
+++ b/meta-agl-early/recipes-benchmark/dmidecode/files/0001-Fix-Redfish-Hostname-print-length.patch
@@ -1,0 +1,30 @@
+From fde47bb227b8fa817c88d7e10a8eb771c46de1df Mon Sep 17 00:00:00 2001
+From: Charles Rose <Charles.Rose@dell.com>
+Date: Mon, 22 Oct 2018 09:48:02 +0200
+Subject: dmidecode: Fix Redfish Hostname print length
+
+Redfish Hostname prints beyond hlen characters. Fix it.
+
+Signed-off-by: Charles Rose <charles.rose@dell.com>
+Fixes: 78539b06117c ("dmidecode: Parse Modern Management Controller blocks")
+Acked-by: Neil Horman <nhorman@tuxdriver.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+---
+ dmidecode.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dmidecode.c b/dmidecode.c
+index a3e9d6c..7ac6438 100644
+--- a/dmidecode.c
++++ b/dmidecode.c
+@@ -3609,7 +3609,7 @@ static void dmi_parse_protocol_record(const char *prefix, u8 *rec)
+ 		hname = out_of_spec;
+ 		hlen = strlen(out_of_spec);
+ 	}
+-	printf("%s\t\tRedfish Service Hostname: %*s\n", prefix, hlen, hname);
++	printf("%s\t\tRedfish Service Hostname: %.*s\n", prefix, hlen, hname);
+ }
+ 
+ /*
+-- 
+cgit v1.0-41-gc330

--- a/meta-agl-early/recipes-benchmark/dmidecode/files/0002-Add-Logical-non-volatile-device-to-the-memory-device-types.patch
+++ b/meta-agl-early/recipes-benchmark/dmidecode/files/0002-Add-Logical-non-volatile-device-to-the-memory-device-types.patch
@@ -1,0 +1,39 @@
+From 74dfb854b8199ddb0a27e89296fa565f4706cb9d Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Wed, 16 Jan 2019 09:04:55 +0100
+Subject: dmidecode: Add "Logical non-volatile device" to the memory device
+ types
+
+When adding support for non-volative memory, we forgot to add
+"Logical non-volatile device" to the list of memory types. This
+causes NVDIMM modules to show up as <OUT OF SPEC>. Fix the problem
+by adding the missing enumerated value.
+
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Reviewed-by: Jerry Hoemann <jerry.hoemann@hpe.com>
+---
+ dmidecode.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/dmidecode.c b/dmidecode.c
+index 903ef35..91c6f62 100644
+--- a/dmidecode.c
++++ b/dmidecode.c
+@@ -2471,10 +2471,11 @@ static const char *dmi_memory_device_type(u8 code)
+ 		"LPDDR",
+ 		"LPDDR2",
+ 		"LPDDR3",
+-		"LPDDR4" /* 0x1E */
++		"LPDDR4",
++		"Logical non-volatile device" /* 0x1F */
+ 	};
+ 
+-	if (code >= 0x01 && code <= 0x1E)
++	if (code >= 0x01 && code <= 0x1F)
+ 		return type[code - 0x01];
+ 	return out_of_spec;
+ }
+-- 
+cgit v1.0-41-gc330
+
+

--- a/meta-agl-early/recipes-benchmark/packagegroups/packagegroup-benchmark.bb
+++ b/meta-agl-early/recipes-benchmark/packagegroups/packagegroup-benchmark.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Benchmark testing packages"
+
+LICENSE = "MIT"
+
+inherit packagegroup
+
+PACKAGES = " \
+    packagegroup-benchmark \
+"
+
+RDEPENDS_packagegroup-benchmark = " \
+    stress-ng \
+    glmark2 \
+	dmidecode \
+    pciutils \
+    platform-benchmark \
+"

--- a/meta-agl-early/recipes-benchmark/stress-ng/stress-ng_0.09.57.bb
+++ b/meta-agl-early/recipes-benchmark/stress-ng/stress-ng_0.09.57.bb
@@ -1,0 +1,21 @@
+SUMMARY = "A tool to load and stress a computer system"
+HOMEPAGE = "http://kernel.ubuntu.com/~cking/stress-ng/"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+DEPENDS = "zlib libaio"
+
+SRC_URI = "http://kernel.ubuntu.com/~cking/tarballs/${BPN}/${BP}.tar.xz \
+           "
+SRC_URI[md5sum] = "2b2f06af29fb0d4a8f172a8b5bf3c71a"
+SRC_URI[sha256sum] = "5d006097a17ff67abfa11c13a15cf92f380c5f56eac1c69a6410b938432de576"
+
+UPSTREAM_CHECK_URI ?= "http://kernel.ubuntu.com/~cking/tarballs/${BPN}/"
+UPSTREAM_CHECK_REGEX ?= "(?P<pver>\d+(\.\d+)+)\.tar"
+
+CFLAGS += "-Wall -Wextra -DVERSION='"$(VERSION)"'"
+
+do_install_append() {
+    install -d ${D}${bindir}
+    install -m 755 ${S}/stress-ng ${D}${bindir}/stress-ng
+}

--- a/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
+++ b/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
@@ -125,13 +125,13 @@ print_result()
 {
 	if [ $1 == "CPU" ]
 	then
-		CPU_SCORE=$(grep "] cpu" $CPU_LOG_FILE | awk -F"] cpu" '{print $2}' | sed -e 's/^[ \t]*//' | cut -d' ' -f1)
+		CPU_SCORE=$(grep "] cpu" $CPU_LOG_FILE | awk -F"] cpu" '{print $2}' | sed -e 's/^[ \t]*//' | awk -F" " '{print $5}' | cut -d'.' -f1)
 		echo -en "\r * CPU Results :  \n"
 		echo -e "   - Stress-ng : $gr$CPU_SCORE$nc"
 
 	elif [ $1 == "RAM" ]
 	then
-		RAM_SCORE=$(grep "] vm" $RAM_LOG_FILE | awk -F"] vm" '{print $2}' | sed -e 's/^[ \t]*//' | cut -d' ' -f1)
+		RAM_SCORE=$(grep "] vm" $RAM_LOG_FILE | awk -F"] vm" '{print $2}' | sed -e 's/^[ \t]*//' | awk -F" " '{print $5}' | cut -d'.' -f1)
 		echo -en "\r * RAM Results :  \n"
 		echo -e "   - Stress-ng : $gr$RAM_SCORE$nc"
 

--- a/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
+++ b/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
@@ -32,15 +32,17 @@ EOF
 	exit 1
 }
 
-TEMP=$(getopt -o vh -l verbose,help -n $SCRIPT -- "$@")
+TEMP=$(getopt -o svh -l show-details,verbose,help -n $SCRIPT -- "$@")
 [[ $? != 0 ]] && usage
 eval set -- "$TEMP"
 
 #default options values
 VERBOSE=0
+SHOW_DETAILS=0
 
 while true; do
 	case "$1" in
+		-s|--show-details) SHOW_DETAILS=1; shift ;;
 		-v|--verbose) VERBOSE=1; shift ;;
 		-h|--help) HELP=1; shift ;;
 		--) shift; break;;
@@ -90,22 +92,33 @@ sys_info()
 		MEM_SPEED=$(grep -i "Speed" /tmp/raminfo.log | awk -F": " '{print $2}' | head -1)
 	fi
 
-	GPU_NAME=$(lspci  -v -s  $(lspci | grep ' VGA ' | cut -d" " -f 1) | grep "Subsystem" | awk -F": " '{print $2}')
+	GPU_BUS=$(lspci | grep ' VGA ' | cut -d" " -f 1)
+	if [ "$GPU_BUS" != "" ]
+	then
+		GPU_NAME=$(lspci  -v -s  $(GPU_BUS) | grep "Subsystem" | awk -F": " '{print $2}')
+	else
+		GPU_NAME="N/A"
+	fi
 
-	echo -en "\r Hardware information :\n"
-	echo -e " * CPU : $CPU_NAME"
-	echo -e "   - Cores : $CPU_NB_CORE"
-	echo -e "   - Freq  : $CPU_FREQ"
-	echo -e "   - Cache : $CPU_CACHE_SIZE"
-	echo -e "   - Bogo  : $CPU_BOGO_MIPS MIPS"
+	if [[ "$SHOW_DETAILS" == 1 ]]
+	then
+		echo -en "\r Hardware information :\n"
+		echo -e " * CPU : $CPU_NAME"
+		echo -e "   - Cores : $CPU_NB_CORE"
+		echo -e "   - Freq  : $CPU_FREQ"
+		echo -e "   - Cache : $CPU_CACHE_SIZE"
+		echo -e "   - Bogo  : $CPU_BOGO_MIPS MIPS"
 
-	echo -e " * RAM : $RAM_NAME"
-	echo -e "   - Size  : $MEM_SIZE"
-	echo -e "   - Speed : $MEM_SPEED"
+		echo -e " * RAM : $RAM_NAME"
+		echo -e "   - Size  : $MEM_SIZE"
+		echo -e "   - Speed : $MEM_SPEED"
 
-	echo -e " * GPU : $GPU_NAME"
-#	echo -e "   - Freq  : $GPU_FREQ MHz"
-	echo    ""
+		echo -e " * GPU : $GPU_NAME"
+# 		echo -e "   - Freq  : $GPU_FREQ MHz"
+		echo    ""
+	else
+		echo -en " OK.\n\n"
+	fi
 }
 
 print_result()

--- a/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
+++ b/meta-agl-early/recipes-core/platform-benchmark/files/agl-benchmark
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+vMAJOR=0
+vMINOR=1
+
+VERSION=${vMAJOR}.${vMINOR}
+
+SCRIPT=$(basename $BASH_SOURCE)
+
+rd='\e[0;31m'
+gr='\e[0;32m'
+yl='\e[0;33m'
+bl='\e[0;34m'
+nc='\e[0m' # no color
+
+CPU_LOG_FILE=/tmp/agl-benchmark.testcpu.log
+RAM_LOG_FILE=/tmp/agl-benchmark.testram.log
+GPU_LOG_FILE=/tmp/agl-benchmark.testgpu.log
+
+function usage() {
+	cat <<EOF >&2
+Usage: $SCRIPT [options]
+
+Options:
+   -v|--verbose
+      show all output messages
+      default: off
+   -h|--help
+      get this help
+
+EOF
+	exit 1
+}
+
+TEMP=$(getopt -o vh -l verbose,help -n $SCRIPT -- "$@")
+[[ $? != 0 ]] && usage
+eval set -- "$TEMP"
+
+#default options values
+VERBOSE=0
+
+while true; do
+	case "$1" in
+		-v|--verbose) VERBOSE=1; shift ;;
+		-h|--help) HELP=1; shift ;;
+		--) shift; break;;
+		*) error "Internal error"; exit 1;;
+	esac
+done
+
+[[ "$HELP" == 1 ]] && usage
+
+clean()
+{
+	if [ -f $CPU_LOG_FILE ]
+	then rm $CPU_LOG_FILE
+	fi
+
+	if [ -f $RAM_LOG_FILE ]
+	then rm $RAM_LOG_FILE
+	fi
+
+	if [ -f $GPU_LOG_FILE ]
+	then rm $GPU_LOG_FILE
+	fi
+}
+sys_info()
+{
+	#Start by identifying general system information
+
+	echo -en " Scanning hardware..."
+
+	CPU_NAME=$(cat /proc/cpuinfo | grep -i "^model name" | awk -F": " '{print $2}' | head -1 | sed 's/ \+/ /g')
+	CPU_NB_CORE=$(cat /proc/cpuinfo | grep -i "^processor" | wc -l)
+	CPU_FREQ=$(cat /proc/cpuinfo | grep -i "^model name" | awk -F"@ " '{print $2}' | head -1)
+	CPU_CACHE_SIZE=$(cat /proc/cpuinfo | grep -i "^cache size" | awk -F": " '{print $2}' | head -1)
+	CPU_BOGO_MIPS=$(cat /proc/cpuinfo | grep -i "^bogomips" | awk -F": " '{print $2}' | head -1)
+
+	if [ "$EUID" -ne 0 ]
+	then
+		RAM_NAME="N/A"
+		MEM_SIZE=$(awk '/MemTotal/ {print $2}' /proc/meminfo)" kB"
+		MEM_SPEED="N/A"
+	else
+		dmidecode --type 17 &> /tmp/raminfo.log
+		RAM_BREND=$(grep -i "Manufacturer" /tmp/raminfo.log | awk -F": " '{print $2}' | head -1)
+		RAM_PN=$(grep -i "Part Number" /tmp/raminfo.log | awk -F": " '{print $2}' | head -1)
+		RAM_NAME=$RAM_BREND" "$RAM_PN
+		MEM_SIZE=$(grep -i "Size" /tmp/raminfo.log | awk -F": " '{print $2}' | head -1)
+		MEM_SPEED=$(grep -i "Speed" /tmp/raminfo.log | awk -F": " '{print $2}' | head -1)
+	fi
+
+	GPU_NAME=$(lspci  -v -s  $(lspci | grep ' VGA ' | cut -d" " -f 1) | grep "Subsystem" | awk -F": " '{print $2}')
+
+	echo -en "\r Hardware information :\n"
+	echo -e " * CPU : $CPU_NAME"
+	echo -e "   - Cores : $CPU_NB_CORE"
+	echo -e "   - Freq  : $CPU_FREQ"
+	echo -e "   - Cache : $CPU_CACHE_SIZE"
+	echo -e "   - Bogo  : $CPU_BOGO_MIPS MIPS"
+
+	echo -e " * RAM : $RAM_NAME"
+	echo -e "   - Size  : $MEM_SIZE"
+	echo -e "   - Speed : $MEM_SPEED"
+
+	echo -e " * GPU : $GPU_NAME"
+#	echo -e "   - Freq  : $GPU_FREQ MHz"
+	echo    ""
+}
+
+print_result()
+{
+	if [ $1 == "CPU" ]
+	then
+		CPU_SCORE=$(grep "] cpu" $CPU_LOG_FILE | awk -F"] cpu" '{print $2}' | sed -e 's/^[ \t]*//' | cut -d' ' -f1)
+		echo -en "\r * CPU Results :  \n"
+		echo -e "   - Stress-ng : $gr$CPU_SCORE$nc"
+
+	elif [ $1 == "RAM" ]
+	then
+		RAM_SCORE=$(grep "] vm" $RAM_LOG_FILE | awk -F"] vm" '{print $2}' | sed -e 's/^[ \t]*//' | cut -d' ' -f1)
+		echo -en "\r * RAM Results :  \n"
+		echo -e "   - Stress-ng : $gr$RAM_SCORE$nc"
+
+	elif [ $1 == "GPU" ]
+	then
+		GPU_SCORE=$(grep "glmark2 Score" $GPU_LOG_FILE | awk -F": " '{print $2}' | cut -d' ' -f1)
+		echo -en "\r * GPU Results :  \n"
+		echo -e "   - glmark2   : $gr$GPU_SCORE$nc"
+	fi
+}
+
+launch_all_tests()
+{
+	echo " Start benchmarking..."
+
+	#CPU benchmarking
+	if [ $VERBOSE -eq 1 ]
+	then
+		tail -f $CPU_LOG_FILE &
+	fi
+	echo -en " * CPU Testing..."
+	stress-ng --cpu $CPU_NB_CORE --cpu-method fft --metrics-brief --timeout 5s &> $CPU_LOG_FILE
+	print_result "CPU"
+
+	#RAM benchmarking
+	if [ $VERBOSE -eq 1 ]
+	then
+		tail -f $RAM_LOG_FILE &
+	fi
+	echo -en " * RAM Testing..."
+	stress-ng --vm 1 --vm-bytes 128M --metrics-brief --timeout 5s &> $RAM_LOG_FILE
+	print_result "RAM"
+
+	#GPU benchmarking
+	if [ $VERBOSE -eq 1 ]
+	then
+		tail -f $GPU_LOG_FILE &
+	fi
+	echo -en " * GPU Testing..."
+	glmark2-es2-wayland --off-screen &> $GPU_LOG_FILE
+	print_result "GPU"
+
+	echo ""
+
+	AGL_SCORE=$(($CPU_SCORE*45+$RAM_SCORE*5+$GPU_SCORE*50))
+	AGL_SCORE=$(($AGL_SCORE/100))
+}
+
+###############################################################################################
+
+
+echo -e "$rd######################################"
+echo -e "#$nc   AGL Benchmarking script - v$VERSION   $rd#"
+echo -e "$rd######################################$nc\n"
+
+
+clean
+
+sys_info
+
+launch_all_tests
+
+
+echo -e "$rd######################################"
+printf "#$nc Your AGL Benchmarking score: $gr%5s $rd#\n" $AGL_SCORE
+echo -e "$rd######################################$nc\n"
+
+exit 0

--- a/meta-agl-early/recipes-core/platform-benchmark/platform-benchmark_%.bb
+++ b/meta-agl-early/recipes-core/platform-benchmark/platform-benchmark_%.bb
@@ -1,0 +1,21 @@
+SUMMARY     = "Script to run benchmark tools"
+DESCRIPTION = "Run a subset of defined stress and benchmark test in order to obtain an indicator of the system performance."
+HOMEPAGE = "https://github.com/iotbzh/meta-iot-bzh/tree/master/meta-agl-early/recipes-core/platform-benchmark"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI =  " \
+    file://agl-benchmark \
+"
+
+PV = "0.1"
+
+RDEPENDS_${PN}  += "bash"
+
+SRC_URI[md5sum]="0ed923c8b3d17cdf91c8f20e9a634706"
+
+do_install () {
+    install -d ${D}/${sbindir}
+    install -m 0755 ${WORKDIR}/agl-benchmark ${D}/${sbindir}
+}

--- a/meta-agl-early/recipes-platform/packagegroups/packagegroup-agl-core-os-commonlibs.bbappend
+++ b/meta-agl-early/recipes-platform/packagegroups/packagegroup-agl-core-os-commonlibs.bbappend
@@ -1,5 +1,6 @@
 RDEPENDS_${PN} += "\
 	iotbzh-base-files \
+	packagegroup-benchmark \
 	platform-hardware-info \
 	fix-startup-sequence \
 	xdelta3 \


### PR DESCRIPTION
Use stress-ng and glmark2 to bench the target.
Add a script to realize a test on CPU, RAM and GPU to quickly obtain
a benchmark score.

Add dmidecode and pciutils to get details on system hardware.

Signed-off-by: Pierre MARZIN <pierre.marzin@iot.bzh>